### PR TITLE
Skip MMF matches with no tickets

### DIFF
--- a/main.go
+++ b/main.go
@@ -1048,6 +1048,15 @@ func (s *grpcServer) InvokeMatchmakingFunctions(req *pb.MmfRequest, stream pb.Op
 						}
 					}
 
+					// Skipping deactivation for match with no tickets.
+					if len(ticketIdsToDeactivate) == 0 {
+						logger.WithFields(logrus.Fields{
+							"match_id": res.GetId(),
+							"reason":   "no tickets in match response",
+						}).Warn("Skipping deactivation for match with no tickets.")
+						return
+					}
+
 					// Kick off deactivation
 					logger.Tracef("deactivating tickets in %v", res.GetId())
 					errs := updateTicketsActiveState(ctx, logger, &tc, ticketIdsToDeactivate, store.Deactivate)


### PR DESCRIPTION
This is completely my fault, but when the ticket is empty and Director calls InvokeMatchmakingFunctions, mmf returns a response that doesn't include the ticket, causing om-core to crash.
When this happens, we've set it up so that a warning is displayed and the processing is skipped.
Thank you for your consideration.
Fixes googleforgames/open-match2#20