### PR TITLE
Ignore matches with deactivated tickets

### DIFF
--- a/main.go
+++ b/main.go
@@ -1048,6 +1048,16 @@ func (s *grpcServer) InvokeMatchmakingFunctions(req *pb.MmfRequest, stream pb.Op
 						}
 					}
 
+					// This checks if any of the tickets have been deactivated while the
+					// MMF was running and abandons the match if this is the case.
+					if cfg.GetBool("OM_MATCH_ABANDON_ON_INACTIVE_TICKET") {
+						for _, ticketId := range ticketIdsToDeactivate {
+							if _, ok := tc.InactiveSet.Load(ticketId); ok {
+								return;
+							}
+						}
+					}
+
 					// Kick off deactivation
 					logger.Tracef("deactivating tickets in %v", res.GetId())
 					errs := updateTicketsActiveState(ctx, logger, &tc, ticketIdsToDeactivate, store.Deactivate)


### PR DESCRIPTION
This adds an option to automatically drop matches made by a MMF in case tickets were deactivated while the MMF was working.

A real world use case for this would be when the user decides to stop queueing for a match while we are in the process making a match for them. Right now it forces developers to retain a certain amount of state in a non authoritative ticket producer. While this change doesn't fully resolve the race condition, it lowers the likelihood to a (probably) acceptable level.

I've covered the feature with a feature flag to not make it a breaking change.