### PR TITLE
fix: correct ticket deactivation metric calculation

### DIFF
--- a/main.go
+++ b/main.go
@@ -1065,7 +1065,7 @@ func (s *grpcServer) InvokeMatchmakingFunctions(req *pb.MmfRequest, stream pb.Op
 					if len(errs) > 0 {
 						logger.Errorf("Error deactivating match %v tickets: %v", res.GetId(), err)
 					}
-					otelMmfTicketDeactivations.Add(ctx, int64(min(0, len(ticketIdsToDeactivate)-len(errs))),
+					otelMmfTicketDeactivations.Add(ctx, int64(len(ticketIdsToDeactivate)-len(errs)),
 						metric.WithAttributes(
 							attribute.String("mmf.name", mmf.GetName()),
 							attribute.String("profile.name", profileName),


### PR DESCRIPTION
- closes: #26

### Summary
Fixes `otelMmfTicketDeactivations.Add` calculation inside `InvokeMatchmakingFunctions` by removing unnecessary `min()` usage.

### Background
Previously, the metric was calculated as:

```go
min(0, len(ticketIdsToDeactivate)-len(errs))
```

Since len(errs) is derived from updateTicketsActiveState and can never exceed len(ticketIdsToDeactivate), the subtraction result is always >= 0.

As a result, min(0, ...) always returns 0, causing the metric to never increment.

### Root Cause

`updateTicketsActiveState` processes exactly len(ticketIds) responses, adding an error to the map only when a ticket update fails.
Because the map key is the ticket ID (unique), len(errs) cannot exceed len(ticketIds).

```go
	for i := 0; i < len(ticketIds); i++ {
		r := <-rChan
		if r.Err != nil {
			// Wrap redis error and give it a gRPC internal server error status code
			// The results.result field contains the ticket id that generated the error.
			errs[r.Result] = status.Error(codes.Internal, fmt.Errorf("Unable to update ticket %v state to %v : %w", ticketIds[i], requestedStateAsString, r.Err).Error())
			logger.Error(errs[r.Result])
		}
	}
	return errs
```
### Fix
Removed min(0, ...) and directly used:
`len(ticketIdsToDeactivate) - len(errs)`

This correctly increments the metric when tickets are deactivated.

