### PR TITLE
https://github.com/googleforgames/open-match2/issues/32

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -211,7 +211,7 @@ func registerMetrics(meterPointer *otelmetrics.Meter) {
 	}
 
 	otelFailedIdsPerActivateCall, err = meter.Int64Histogram(
-		metricsNamePrefix+"ticket.deactivation.failures.unspecified",
+		metricsNamePrefix+"ticket.activation.failures.unspecified",
 		otelmetrics.WithDescription("Ticket activations per ActivateTickets rpc call that failed due to an unspecified error"),
 	)
 	if err != nil {


### PR DESCRIPTION
Fix name of a failed activation metric